### PR TITLE
#31 -> roles are now retrieved from /roles and /roles/{id}

### DIFF
--- a/src/main/java/com/pi/back/db/Role.java
+++ b/src/main/java/com/pi/back/db/Role.java
@@ -2,8 +2,10 @@ package com.pi.back.db;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -12,7 +14,9 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-@Data
+@Getter
+@Setter
+@EqualsAndHashCode(of = "roleName")
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
@@ -30,4 +34,7 @@ public class Role {
 
     @Column(nullable = false, name = "ROLE")
     private String roleName;
+
+    @Column(nullable = true, name = "ROLE_ID")
+    private Integer roleId;
 }

--- a/src/main/java/com/pi/back/db/RolesRepository.java
+++ b/src/main/java/com/pi/back/db/RolesRepository.java
@@ -1,0 +1,12 @@
+package com.pi.back.db;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RolesRepository extends JpaRepository<Role,Integer> {
+
+    @Query(value =  "SELECT R FROM Role R WHERE R.id = :roleId")
+    Role findRole(int roleId);
+}

--- a/src/main/java/com/pi/back/services/RolesService.java
+++ b/src/main/java/com/pi/back/services/RolesService.java
@@ -1,0 +1,31 @@
+package com.pi.back.services;
+
+import com.pi.back.db.Role;
+import com.pi.back.db.RolesRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+public class RolesService {
+
+    private final RolesRepository rolesRepository;
+
+    @Autowired
+    public RolesService(RolesRepository rolesRepository) {
+        this.rolesRepository = rolesRepository;
+    }
+
+    public List<Role> findAll() {
+        final List<Role> roles = rolesRepository.findAll();
+        log.info("{} roles found", roles.size());
+        return roles;
+    }
+
+    public Role findRole(int roleId) {
+        return rolesRepository.findRole(roleId);
+    }
+}

--- a/src/main/java/com/pi/back/web/RolesController.java
+++ b/src/main/java/com/pi/back/web/RolesController.java
@@ -1,0 +1,58 @@
+package com.pi.back.web;
+
+import com.pi.back.db.Role;
+import com.pi.back.services.RolesService;
+import com.pi.back.web.roles.RoleResponse;
+import com.pi.back.web.roles.RolesResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@RestController
+public class RolesController {
+
+    private final RolesService rolesService;
+
+    @Autowired
+    public RolesController(RolesService rolesService) {
+        this.rolesService = rolesService;
+    }
+
+    @GetMapping("/roles")
+    public ResponseEntity<RolesResponse> fetchRoles() {
+        List<Role> rolesList = rolesService.findAll();
+
+        final List<RoleResponse> rolesListResponse = rolesList.stream()
+                .distinct()
+                .map(RoleResponse::newInstance)
+                .collect(Collectors.toList());
+
+        if (rolesListResponse.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(RolesResponse
+                .builder()
+                .roles(rolesListResponse)
+                .build());
+    }
+
+    @GetMapping("/roles/{roleId}")
+    public ResponseEntity<RoleResponse> fetchRole(@PathVariable(name = "roleId") Integer roleId) {
+        List<Role> rolesList = rolesService.findAll();
+
+        return rolesList.stream()
+                .distinct()
+                .filter(r -> r.getRoleId().equals(roleId))
+                .findFirst()
+                .map(RoleResponse::newDetailedInstance)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.noContent().build());
+    }
+}

--- a/src/main/java/com/pi/back/web/roles/RoleResponse.java
+++ b/src/main/java/com/pi/back/web/roles/RoleResponse.java
@@ -1,0 +1,35 @@
+package com.pi.back.web.roles;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.pi.back.db.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RoleResponse {
+
+    private Integer id;
+    private String role;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String description;
+
+    public static final RoleResponse newInstance(Role role) {
+        return RoleResponse.builder()
+                .id(role.getRoleId())
+                .role(role.getRoleName())
+                .build();
+    }
+
+    public static final RoleResponse newDetailedInstance(Role role) {
+        return RoleResponse.builder()
+                .id(role.getRoleId())
+                .role(role.getRoleName())
+                .description(null)
+                .build();
+    }
+}

--- a/src/main/java/com/pi/back/web/roles/RolesResponse.java
+++ b/src/main/java/com/pi/back/web/roles/RolesResponse.java
@@ -1,0 +1,16 @@
+package com.pi.back.web.roles;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class RolesResponse {
+    private List<RoleResponse> roles;
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -4,6 +4,7 @@ create table if not exists role
     id      int primary key auto_increment,
     user_id int         not null,
     role    varchar(15) not null,
+    role_id int,
 
     foreign key (user_id) references user (id)
 );
@@ -27,11 +28,11 @@ values ('falcon', 'TomasPinp', 'Tomas Santiago Piñero', '20-39445871-7', 'addre
        ('crow', 'UserPinp', 'Howard Conan', '20-31589741-7', 'address4@email.com');
 
 -- load roles table
-insert into role(user_id, role)
-values (1, 'ROLE_ROOT'),
-       (2, 'ROLE_ROOT'),
-       (1, 'ROLE_ADMIN'),
-       (3, 'ROLE_ADMIN'),
-       (4, 'ROLE_USER');
+insert into role(user_id, role, role_id)
+values (1, 'ROLE_ROOT', 1),
+       (2, 'ROLE_ROOT', 1),
+       (1, 'ROLE_ADMIN', 2),
+       (3, 'ROLE_ADMIN', 2),
+       (4, 'ROLE_USER', 3);
 
 commit;


### PR DESCRIPTION
Closes #31
Los roles se pueden listar todos o especificamente alguno mediante `GET /roles` y `GET /roles/{id}` respectivamente