### PR TITLE
#55 -> fix return message when id not exists

### DIFF
--- a/src/main/java/com/pi/back/services/UsersService.java
+++ b/src/main/java/com/pi/back/services/UsersService.java
@@ -110,9 +110,9 @@ public class UsersService {
     public void delete(Integer userId) throws NoSuchElementException {
         final Optional<User> userToDelete = usersRepository.findById(userId);
 
-        if (userToDelete.isEmpty()) {
+        if (userToDelete.isEmpty()) { // esto debiera retornar NoSuchElementException
             log.error("Non-existent user with id {} requested for deleting.", userId);
-            throw new InvalidParameterException("Requested user deletion failed: User with such ID does not exist.");
+            throw new NoSuchElementException("Requested user deletion failed: User with such ID does not exist.");
         }
 
         if (userId == 0) {

--- a/src/test/java/com/pi/back/services/UsersServiceTest.java
+++ b/src/test/java/com/pi/back/services/UsersServiceTest.java
@@ -308,20 +308,20 @@ class UsersServiceTest {
         @Test
         @DisplayName("when user to delete has id 0 then throw InvalidParameterException")
         void deleteUserWithIdZero() {
-            when(usersRepository.findById(any())).thenReturn(Optional.empty());
-
-            assertThrows(InvalidParameterException.class, () -> sut.delete(any()));
-        }
-
-        @Test
-        @DisplayName("when user to delete has id null then throw InvalidParameterException")
-        void deleteUserWithIdNull() {
             User mockUserToDelete = User.builder()
                     .build();
 
             when(usersRepository.findById(any())).thenReturn(Optional.of(mockUserToDelete));
 
             assertThrows(InvalidParameterException.class, () -> sut.delete(0));
+        }
+
+        @Test
+        @DisplayName("when user to delete has non existent then throw NoSuchElementException")
+        void deleteUserWithIdNull() {
+            when(usersRepository.findById(any())).thenReturn(Optional.empty());
+
+            assertThrows(NoSuchElementException.class, () -> sut.delete(any()));
         }
 
         @Test


### PR DESCRIPTION
closes #55 cuando se manda un /users/userId con {userId} inexistente retorna 404 not found (antes retornaba 412 precondition failed que es para bodys con informacion erronea)