### PR TITLE
#57 -> roles/{roleId} now returns 404 when invalid ID

### DIFF
--- a/src/main/java/com/pi/back/web/RolesController.java
+++ b/src/main/java/com/pi/back/web/RolesController.java
@@ -56,6 +56,6 @@ public class RolesController {
                 .findFirst()
                 .map(RoleResponse::newDetailedInstance)
                 .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.noContent().build());
+                .orElse(ResponseEntity.notFound().build());
     }
 }

--- a/src/test/java/com/pi/back/web/RolesControllerTest.java
+++ b/src/test/java/com/pi/back/web/RolesControllerTest.java
@@ -93,7 +93,7 @@ class RolesControllerTest {
         }
 
         @Test
-        @DisplayName("when specific role is not found then return 204 no content")
+        @DisplayName("when specific role is not found then return 404 not found")
         void roleNotFound() throws Exception {
             List<Privileges> roleList = List.of();
 
@@ -101,7 +101,7 @@ class RolesControllerTest {
 
             mockMvc.perform(get("/roles/1")
                     .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isNoContent());
+                    .andExpect(status().isNotFound());
         }
     }
 }


### PR DESCRIPTION
Closes #57 
retorna 404 cuando se envia un ID no existente a GET /roles/{roleId}