### PR TITLE
issue 72 - swagger documentation is enabled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.5.2</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Closes #72 
para ingresar a la UI de swagger, levantar la app e ingresar a {url:port}/api/swagger-ui

link de utilidad https://www.baeldung.com/spring-rest-openapi-documentation